### PR TITLE
Add Makefiles, fix some compile errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+.PHONY: all clean install uninstall
+
+# Omitted: putr: has no sources.
+all:
+	cd config11 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd converters && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd crossassemblers && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd extracters && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+
+clean:
+	cd config11 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd converters && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd crossassemblers && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd extracters && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+
+install:
+	cd config11 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd converters && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd crossassemblers && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd extracters && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+
+uninstall:
+	cd config11 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd converters && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd crossassemblers && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd extracters && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall

--- a/config11/Makefile
+++ b/config11/Makefile
@@ -1,0 +1,20 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=config11
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/Makefile
+++ b/converters/Makefile
@@ -1,0 +1,92 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+
+CFLAGS="-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow"
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+.PHONY: all clean install uninstall
+
+all:
+	cd asc && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd dtos8cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd hpconvert && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd littcvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd mt2tpc && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd mtcvtfix && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd noff && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd strrem && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd tar2mt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd tpc2mt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd decsys && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd gt7cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd indent && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd m8376 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd mtcvt23 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd mtcvtodd && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd sfmtcvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd strsub && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd tp512cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+
+clean:
+	cd asc && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd dtos8cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd hpconvert && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd littcvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd mt2tpc && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd mtcvtfix && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd noff && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd strrem && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd tar2mt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd tpc2mt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd decsys && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd gt7cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd indent && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd m8376 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd mtcvt23 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd mtcvtodd && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd sfmtcvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd strsub && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd tp512cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+
+install:
+	cd asc && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd dtos8cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd hpconvert && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd littcvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd mt2tpc && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd mtcvtfix && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd noff && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd strrem && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd tar2mt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd tpc2mt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd decsys && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd gt7cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd indent && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd m8376 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd mtcvt23 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd mtcvtodd && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd sfmtcvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd strsub && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd tp512cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+
+uninstall:
+	cd asc && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd dtos8cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd hpconvert && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd littcvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd mt2tpc && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd mtcvtfix && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd noff && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd strrem && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd tar2mt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd tpc2mt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd decsys && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd gt7cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd indent && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd m8376 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd mtcvt23 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd mtcvtodd && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd sfmtcvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd strsub && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd tp512cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall

--- a/converters/asc/Makefile
+++ b/converters/asc/Makefile
@@ -1,0 +1,20 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=asc
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/decsys/Makefile
+++ b/converters/decsys/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=decsys
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/dtos8cvt/Makefile
+++ b/converters/dtos8cvt/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=dtos8cvt
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/gt7cvt/Makefile
+++ b/converters/gt7cvt/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=gt7cvt
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/hpconvert/Makefile
+++ b/converters/hpconvert/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=hpconvert
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/indent/Makefile
+++ b/converters/indent/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=indent
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/littcvt/Makefile
+++ b/converters/littcvt/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=littcvt
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/m8376/Makefile
+++ b/converters/m8376/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=m8376
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/mt2tpc/Makefile
+++ b/converters/mt2tpc/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=mt2tpc
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/mtcvt23/Makefile
+++ b/converters/mtcvt23/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=mtcvtv23
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/mtcvtfix/Makefile
+++ b/converters/mtcvtfix/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=mtcvtfix
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/mtcvtodd/Makefile
+++ b/converters/mtcvtodd/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=mtcvtodd
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/noff/Makefile
+++ b/converters/noff/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=noff
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/sfmtcvt/Makefile
+++ b/converters/sfmtcvt/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=sfmtcvt
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/strrem/Makefile
+++ b/converters/strrem/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=strrem
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/strsub/Makefile
+++ b/converters/strsub/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=strsub
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/tar2mt/Makefile
+++ b/converters/tar2mt/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=tar2mt
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/tp512cvt/Makefile
+++ b/converters/tp512cvt/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=tp512cvt
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/converters/tpc2mt/Makefile
+++ b/converters/tpc2mt/Makefile
@@ -1,0 +1,20 @@
+ # all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=tpc2mt
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/crossassemblers/Makefile
+++ b/crossassemblers/Makefile
@@ -1,0 +1,33 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+.PHONY: all clean install uninstall
+
+# Omitted: macro11: needs more complicated Makefiles.
+all:
+	cd hpasm && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd macro1 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd macro7 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd macro8x && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+
+clean:
+	cd hpasm && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd macro1 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd macro7 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd macro8x && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+
+install:
+	cd hpasm && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd macro1 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd macro7 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd macro8x && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+
+uninstall:
+	cd hpasm && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd macro1 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd macro7 && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd macro8x && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall

--- a/crossassemblers/hpasm/Makefile
+++ b/crossassemblers/hpasm/Makefile
@@ -1,0 +1,20 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=hpasm
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/crossassemblers/macro1/Makefile
+++ b/crossassemblers/macro1/Makefile
@@ -1,0 +1,20 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=macro1
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/crossassemblers/macro7/Makefile
+++ b/crossassemblers/macro7/Makefile
@@ -1,0 +1,20 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=macro7
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/crossassemblers/macro8x/Makefile
+++ b/crossassemblers/macro8x/Makefile
@@ -1,0 +1,20 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=macro8x
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/extracters/Makefile
+++ b/extracters/Makefile
@@ -1,0 +1,41 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+.PHONY: all clean install uninstall
+
+# Omitted: backup, ods2: need more complicated Makefiles.
+all:
+	cd ckabstape && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd mmdir && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd mtdump && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd rawcopy && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd sdsdump && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+	cd tpdump && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)"
+
+clean:
+	cd ckabstape && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd mmdir && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd mtdump && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd rawcopy && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd sdsdump && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd tpdump && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+
+install:
+	cd ckabstape && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd mmdir && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd mtdump && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd rawcopy && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd sdsdump && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+	cd tpdump && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" install
+
+uninstall:
+	cd ckabstape && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd mmdir && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd mtdump && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd rawcopy && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd sdsdump && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall
+	cd tpdump && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" uninstall

--- a/extracters/ckabstape/Makefile
+++ b/extracters/ckabstape/Makefile
@@ -1,0 +1,20 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=ckabstape
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/extracters/ckabstape/ckabstape.c
+++ b/extracters/ckabstape/ckabstape.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 static unsigned char sixlut[64] = {
 '@','A','B','C','D','E','F','G', 
@@ -41,8 +42,8 @@ unsigned int readframe()
 	do{
 	 c = getchar(); 
 	 if(feof(stdin)) 
-	  exit();
-	  if((c & 0x80) == 0) printf("{nul}\n",c);
+	  exit(0);
+	  if((c & 0x80) == 0) printf("{nul}\n");
 	} while((c & 0x80) == 0);
 
 	i =    ((c & 0xc0)>>6)<<27;
@@ -50,8 +51,8 @@ unsigned int readframe()
 	do{
 	 c = getchar(); 
 	 if(feof(stdin)) 
-	  exit();
-	  if((c & 0x80) == 0) printf("{nul}\n",c);
+	  exit(0);
+	  if((c & 0x80) == 0) printf("{nul}\n");
 	} while((c & 0x80) == 0);
 
 	i = i |((c & 0xc0)>>6)<<24;
@@ -60,8 +61,8 @@ unsigned int readframe()
 	do{
 	 c = getchar(); 
 	 if(feof(stdin)) 
-	  exit();
-	  if((c & 0x80) == 0) printf("{nul}\n",c);
+	  exit(0);
+	  if((c & 0x80) == 0) printf("{nul}\n");
 	} while((c & 0x80) == 0);
 
 	i = i |((c & 0xc0)>>6)<<21;
@@ -69,7 +70,7 @@ unsigned int readframe()
 	return i;
 }
 
-disasm(unsigned int instr)
+void disasm(unsigned int instr)
 {
 	char *idx;
 	if(instr & 0010000) idx = ",X"; else idx = "  ";
@@ -248,7 +249,7 @@ disasm(unsigned int instr)
 	 case(0740000):
 	  printf("NOP         ");
 	  break;
-	 case(0740001):		// CMA compliment AC
+	 case(0740001):		/* CMA compliment AC */
 	  printf("CMA         ");
 	  break;
 	 case(0740002):
@@ -335,19 +336,20 @@ disasm(unsigned int instr)
 	}
 }
 
-main()
+int main(int argc, char **argv)
 {
 	int totalblks = 0;
 	int badblks = 0;
-	unsigned int fullwd = 0;
 	unsigned int currentwd = 0;
-	int wds = 0;
 	int bytecnt = 0;	
 	int col = 0;
 	int framecount;
 	unsigned int cksum;
 	unsigned int adr;
-        unsigned char c;
+
+        (void) argc;
+        (void) argv;
+
 	/*
 	 *  read 3 chars and pack them in a word 
 	 */
@@ -373,22 +375,22 @@ main()
 	      * (check is in readframe..)
 	      */
 
-	       adr = readframe() & 0777777;		// staring adr
+                  adr = readframe() & 0777777;		/*staring adr */
 	       cksum = adr;
 	       printf("ADR: %010o\n", adr);
 
-	       framecount = readframe() & 0777777;	// word count
+	       framecount = readframe() & 0777777;	/* word count */
 	       cksum += framecount;
-	       framecount = -(0xfffe0000 | framecount); // sign extend
+	       framecount = -(0xfffe0000 | framecount); /* sign extend */
 	       printf("CNT: %010o (%d)\n", framecount, framecount);
 
 	       if((adr & 0700000) != 0){
 	        printf("FRAMECOUNT == 0 START ADR == %06o\n", adr);
 		printf("TOTAL BLKS %d TOTAL ERRS %d\n", totalblks, badblks);
-	        exit();
+	        exit(0);
 	       }
 
-	       currentwd = readframe() & 0777777;		// checksum
+	       currentwd = readframe() & 0777777;		/* checksum */
 	       cksum += currentwd;
 	       printf("CKS: %06o\n", currentwd);
 	       /*
@@ -419,5 +421,7 @@ main()
 	if(bytecnt > 0){
 	 printf("%d chrs left\n", bytecnt);
 	}
+
+        exit(0);
 }
 

--- a/extracters/mmdir/Makefile
+++ b/extracters/mmdir/Makefile
@@ -1,0 +1,20 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=mmdir
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/extracters/mtdump/Makefile
+++ b/extracters/mtdump/Makefile
@@ -1,0 +1,20 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=mtdump
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/extracters/mtdump/mtdump.c
+++ b/extracters/mtdump/mtdump.c
@@ -42,9 +42,10 @@
 int main (int argc, char *argv[])
 {
 int obj, i, k, fc, rc, tpos;
-unsigned int bc, fmt, rlntsiz;
-unsigned char *s, bca[4];
-int preveof, gapcount, gpos, gincr;
+unsigned int bc = 0, fmt, rlntsiz;
+ unsigned char *s;
+ unsigned char bca[4] = { 0,0,0,0 };
+int preveof, gapcount, gpos = 0, gincr;
 FILE *ifile;
 #define MAXRLNT 65536
 
@@ -62,7 +63,7 @@ if ((s != NULL) && (*s++ == '-')) {
 	    fmt = F_E11; rlntsiz = 4; break;
         case 'C': case 'c':
 	    fmt = F_TPC; rlntsiz = 2; break;
-/*	case 'F': case 'f':
+            /*	case 'F': case 'f': */
 /*	    fmt = F_TPF; break; */
 	default:
 	    fprintf (stderr, "Bad option %c\n", *s);

--- a/extracters/rawcopy/Makefile
+++ b/extracters/rawcopy/Makefile
@@ -1,0 +1,20 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=RawCopy
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/extracters/rawcopy/RawCopy.c
+++ b/extracters/rawcopy/RawCopy.c
@@ -34,7 +34,7 @@ while (0 != (bytesread = fread(buf, 1, readsize, fin)))
     {
     if (bytesread != fwrite(buf, 1, bytesread, fout))
         {
-        fprintf(stderr, "Error Writing '%s': %s\n", strerror(errno));
+            fprintf(stderr, "Error Writing '%s': %s\n", argv[2], strerror(errno));
         break;
         }
     else
@@ -46,4 +46,5 @@ fprintf(stderr, "\n");
 fprintf(stderr, "Total Data: %6.2f MBytes (%d bytes)\n", totalbytes/(1024.0*1024.0), totalbytes);
 fclose(fin);
 fclose(fout);
+ exit(0);
 }

--- a/extracters/sdsdump/Makefile
+++ b/extracters/sdsdump/Makefile
@@ -1,0 +1,20 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=sdsdump
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/extracters/tpdump/Makefile
+++ b/extracters/tpdump/Makefile
@@ -1,0 +1,20 @@
+# all of these can be over-ridden on the "make" command line if they don't suit your environment.
+TOOL=tpdump
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+BIN=/usr/local/bin
+INSTALL=install
+CC=gcc
+
+$(TOOL): $(TOOL).c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f $(TOOL)
+
+install: $(TOOL)
+	$(INSTALL) -p -m u=rx,g=rx,o=rx $(TOOL) $(BIN)
+
+uninstall:
+	rm -f $(BIN)/$(TOOL)

--- a/extracters/tpdump/tpdump.c
+++ b/extracters/tpdump/tpdump.c
@@ -49,7 +49,6 @@ size_t read_len ( FILE* fi )
 /* Read a little-endian four-byte number */
 { unsigned char c;      /* A Character from the file */
   size_t i;
-  size_t lc;            /* The character, as a long int */
   size_t n;             /* the number */
   if ( fread ( &c, 1, 1, fi ) == 0 )
     return (0);
@@ -80,7 +79,7 @@ void usage ( char* argv[] )
   printf ( "          -o Use the 'old simh' print arrangement\n");
 }
 
-main ( int argc, char* argv[] )
+int main ( int argc, char* argv[] )
 { FILE* fi;
   int all;              /* "print all of a record, even blank lines" */
   char* bcd_to_ascii;   /* Translation table, ..._a or ..._h */
@@ -136,7 +135,7 @@ main ( int argc, char* argv[] )
       for ( nb=1, i=np; i>0; i/=10, nb++ ) pr[np-nb] = '0' + ( i%10 );
     printf ( "       %s\n", pr );
     nr = 0;
-    while ( recsiz = read_len ( fi ) )
+    while ( (recsiz = read_len ( fi )) )
     { nb = 1;
       nr++;
       i = recsiz;
@@ -148,7 +147,7 @@ main ( int argc, char* argv[] )
             return(3);
           }
           i--;
-          pr[np] = bcd_to_ascii[pr[np]];
+          pr[np] = bcd_to_ascii[(unsigned int)pr[np]];
           if ( dowm )
             if ( pr[np] == bcd_to_ascii[BCD_WM] ) wm[np--] = '1';
         }
@@ -181,4 +180,5 @@ main ( int argc, char* argv[] )
     }
     if ( nf > 0 ) printf ( "File %d\n", ++nft );
   }
+  return(0);
 }


### PR DESCRIPTION
This fixes a bunch of compile errors, and added Makefiles for most of the tools

I only created Makefiles for the 1-file tools (which is most of them), as I could automate the process.

Omitted are macro11, backup, ods2, and putr.  Putr has no source code.  The others just need the human touch.

There is a top-level Makefile that will build everything that has a Makefile; a Makefile at each group directory, and then one for each tool.  They default to reasonably current GCC, but you can pass CFLAGS, BIN and CC from any Makefile.  The targets are 'all' (for the superfiles), clean, install and uninstall.  

They are not pretty, but they were easy to script and they should work with most makes - the only GMakeism is .PHONY.

I'm not planning to do Makefiles for the others, or to make the windows project files.

There are more compile errors, especially in the cross-assemblers.

But I'm leaving those for someone else.  I'm not planning to become the tool maintainer.  This is just something quick & dirty that I needed and thought I should share.
