### PR TITLE
Eliminate clang warnings when compiling on FreeBSD 10.1R

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # all of these can be over-ridden on the "make" command line if they don't suit your environment.
 
-CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow -Wno-missing-field-initializers
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 .PHONY: all clean install uninstall
 

--- a/config11/Makefile
+++ b/config11/Makefile
@@ -3,7 +3,7 @@ TOOL=config11
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/config11/config11.c
+++ b/config11/config11.c
@@ -29,6 +29,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 #define RANK_LNT	34	
 
@@ -57,12 +58,14 @@ char *namtab[RANK_LNT] = {
 
 int main (int argc, char *argv[])
 {
+(void)argc; /* unused */
+(void)argv; /* unused */
 for ( ;; ) {
     for (i = 0; i < RANK_LNT; i++) numctl[i] = 0;
     printf ("Enter configuration data\n");
     for ( ;; ) {
 	printf ("Name:\t");
-	if (gets (inp) == NULL) return 0;
+	if (fgets (inp, sizeof inp, stdin) == NULL) return 0;
 	if (*inp == 0) break;
 	for (cp = inp; *cp != 0; cp++) *cp = toupper (*cp);
 	for (rank = 0; rank < RANK_LNT; rank++) {
@@ -75,7 +78,7 @@ for ( ;; ) {
 	    printf ("\n");
 	    continue;  }
 	printf ("Number:\t");
-	gets (inp);
+	fgets (inp, sizeof inp, stdin);
 	errno = 0;
 	num = strtoul (inp, &ocp, 10);
 	if (errno || (inp == ocp)) {
@@ -101,7 +104,7 @@ for ( ;; ) {
 	    for (j = 1; j < numctl[i]; j++) {
 		printf ("\t\t  %d\t%06o\n", j + 1, csr);
 		csr = (csr + modtab[i] + 1) & ~modtab[i];  }
-	    printf (" %\t\tgap\t%06o\n", csr);
+	    printf (" %%\t\tgap\t%06o\n", csr);
 	    }
 	if ((i + 1) < RANK_LNT) csr = (csr + modtab[i+1] + 1) & ~modtab[i+1];
 	}

--- a/converters/Makefile
+++ b/converters/Makefile
@@ -1,9 +1,9 @@
 # all of these can be over-ridden on the "make" command line if they don't suit your environment.
 
-CFLAGS="-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow"
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 .PHONY: all clean install uninstall
 

--- a/converters/asc/Makefile
+++ b/converters/asc/Makefile
@@ -3,7 +3,7 @@ TOOL=asc
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/asc/asc.c
+++ b/converters/asc/asc.c
@@ -71,7 +71,7 @@ else mode = MD_WIN;
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".new");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".new");
             else strcat (oname, ".new");
 	ifile = fopen (argv[i], "rb");
 	if (ifile == NULL) {

--- a/converters/decsys/Makefile
+++ b/converters/decsys/Makefile
@@ -3,7 +3,7 @@ TOOL=decsys
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/decsys/decsys.c
+++ b/converters/decsys/decsys.c
@@ -42,7 +42,7 @@ if ((argc < 2) || (argv[0] == NULL)) {
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".dtp");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".dtp");
         else strcat (oname, ".dtp");
 	ifile = fopen (argv[i], "r");
 	if (ifile == NULL) {

--- a/converters/dtos8cvt/Makefile
+++ b/converters/dtos8cvt/Makefile
@@ -3,7 +3,7 @@ TOOL=dtos8cvt
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/dtos8cvt/dtos8cvt.c
+++ b/converters/dtos8cvt/dtos8cvt.c
@@ -42,7 +42,7 @@ if ((argc < 2) || (argv[0] == NULL)) {
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".dt8");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".dt8");
                 else strcat (oname, ".dt8");
 	ifile = fopen (argv[i], "rb");
 	if (ifile == NULL) {

--- a/converters/gt7cvt/Makefile
+++ b/converters/gt7cvt/Makefile
@@ -3,7 +3,7 @@ TOOL=gt7cvt
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/gt7cvt/gt7cvt.c
+++ b/converters/gt7cvt/gt7cvt.c
@@ -31,7 +31,7 @@
 #define FLPSIZ 65536
 unsigned char fzero[4] = { 0 };
 
-int dump_rec (FILE *of, int bc, char *buf)
+int dump_rec (FILE *of, int bc, unsigned char *buf)
 {
 unsigned char buc[4];
 
@@ -62,7 +62,7 @@ if ((argc < 2) || (argv[0] == NULL)) {
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".tap");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".tap");
             else strcat (oname, ".tap");
 	ifile = fopen (argv[i], "rb");
 	if (ifile == NULL) {

--- a/converters/hpconvert/Makefile
+++ b/converters/hpconvert/Makefile
@@ -3,7 +3,7 @@ TOOL=hpconvert
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/hpconvert/hpconvert.c
+++ b/converters/hpconvert/hpconvert.c
@@ -224,7 +224,7 @@ int main (int    argc,
         rewind (fin);
         file_size = fread (sig_fwd, 1, SIGNATURE_SIZE, fin);
 
-        for (i = 0; i < SIGNATURE_SIZE; i = i + 2) {
+        for (i = 0; (size_t)i < SIGNATURE_SIZE; i = i + 2) {
             sig_rev [i]     = sig_fwd [i + 1];
             sig_rev [i + 1] = sig_fwd [i];
             }
@@ -311,7 +311,7 @@ int main (int    argc,
         while (!feof (fin)) {
             record_size = fread (cylinder, 1, CYLINDER_SIZE, fin);
 
-            for (i = 0; i < record_size; i = i + 2) {
+            for (i = 0; (size_t)i < record_size; i = i + 2) {
                 hold = cylinder [i];
                 cylinder [i] = cylinder [i + 1];
                 cylinder [i + 1] = hold;
@@ -363,7 +363,7 @@ int main (int    argc,
 
 /* Swap the bytes. */
 
-                for (i = 0; i < record_size; i = i + 2) {
+                for (i = 0; (size_t)i < record_size; i = i + 2) {
                     hold = cylinder [i];
                     cylinder [i] = cylinder [i + 1];
                     cylinder [i + 1] = hold;

--- a/converters/indent/Makefile
+++ b/converters/indent/Makefile
@@ -3,7 +3,7 @@ TOOL=indent
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/indent/indent.c
+++ b/converters/indent/indent.c
@@ -45,7 +45,7 @@ if ((argc < 2) || (argv[0] == NULL)) {
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".new");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".new");
             else strcat (oname, ".new");
 	ifile = fopen (argv[i], "ra");
 	if (ifile == NULL) {

--- a/converters/littcvt/Makefile
+++ b/converters/littcvt/Makefile
@@ -3,7 +3,7 @@ TOOL=littcvt
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/littcvt/littcvt.c
+++ b/converters/littcvt/littcvt.c
@@ -44,7 +44,7 @@ if ((argc < 2) || (argv[0] == NULL)) {
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".new");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".new");
                 else strcat (oname, ".new");
 	ifile = fopen (argv[i], "rb");
 	if (ifile == NULL) {

--- a/converters/m8376/Makefile
+++ b/converters/m8376/Makefile
@@ -3,7 +3,7 @@ TOOL=m8376
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/m8376/m8376.c
+++ b/converters/m8376/m8376.c
@@ -38,6 +38,8 @@ char fname[256];
 int c, i, j;
 unsigned int wd[1024];
 
+(void)argc; /* unused */
+(void)argv; /* unused */
 for (i = 0; i < 8; i++) {
 	sprintf (fname, "C:\\temp\\m8376\\m8376e%03d.bin", fnum[i]);
 	fi[i] = fopen (fname, "rb");

--- a/converters/mt2tpc/Makefile
+++ b/converters/mt2tpc/Makefile
@@ -3,7 +3,7 @@ TOOL=mt2tpc
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/mt2tpc/mt2tpc.c
+++ b/converters/mt2tpc/mt2tpc.c
@@ -46,7 +46,7 @@ if (argc < 2) {
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".tpc");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".tpc");
                 else strcat (oname, ".tpc");
 	ifile = fopen (argv[i], "rb");
 	if (ifile == NULL) {

--- a/converters/mtcvt23/Makefile
+++ b/converters/mtcvt23/Makefile
@@ -3,7 +3,7 @@ TOOL=mtcvtv23
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/mtcvt23/mtcvtv23.c
+++ b/converters/mtcvt23/mtcvtv23.c
@@ -43,7 +43,7 @@ if ((argc < 2) || (argv[0] == NULL)) {
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".tap");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".tap");
                 else strcat (oname, ".tap");
 	ifile = fopen (argv[i], "rb");
 	if (ifile == NULL) {

--- a/converters/mtcvtfix/Makefile
+++ b/converters/mtcvtfix/Makefile
@@ -3,7 +3,7 @@ TOOL=mtcvtfix
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/mtcvtfix/mtcvtfix.c
+++ b/converters/mtcvtfix/mtcvtfix.c
@@ -45,7 +45,7 @@ if ((argc < 2) || (argv[0] == NULL)) {
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".new");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".new");
             else strcat (oname, ".new");
 	ifile = fopen (argv[i], "rb");
 	if (ifile == NULL) {

--- a/converters/mtcvtodd/Makefile
+++ b/converters/mtcvtodd/Makefile
@@ -3,7 +3,7 @@ TOOL=mtcvtodd
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/mtcvtodd/mtcvtodd.c
+++ b/converters/mtcvtodd/mtcvtodd.c
@@ -43,7 +43,7 @@ if ((argc < 2) || (argv[0] == NULL)) {
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".new");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".new");
                 else strcat (oname, ".new");
 	ifile = fopen (argv[i], "rb");
 	if (ifile == NULL) {

--- a/converters/noff/Makefile
+++ b/converters/noff/Makefile
@@ -3,7 +3,7 @@ TOOL=noff
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/noff/noff.c
+++ b/converters/noff/noff.c
@@ -33,7 +33,7 @@
 int main (int argc, char *argv[])
 {
 int i, c, ffc;
-char *ppos, oline[256], oname[256];
+char *ppos, oname[256];
 FILE *ifile, *ofile;
 
 if ((argc < 2) || (argv[0] == NULL)) {
@@ -42,7 +42,7 @@ if ((argc < 2) || (argv[0] == NULL)) {
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".new");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".new");
             else strcat (oname, ".new");
 	ifile = fopen (argv[i], "ra");
 	if (ifile == NULL) {

--- a/converters/sfmtcvt/Makefile
+++ b/converters/sfmtcvt/Makefile
@@ -3,7 +3,7 @@ TOOL=sfmtcvt
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/sfmtcvt/sfmtcvt.c
+++ b/converters/sfmtcvt/sfmtcvt.c
@@ -97,7 +97,7 @@ for (i = 1, numf = 0; i < argc; i++) {
 			maxaddr[0], k, maxaddr[k]);
 		    return 0;  }  }
 	    strcpy (oname, argv[i]);
-            if (ppos = strrchr (oname, '.')) strcpy (ppos, ".bin");
+            if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".bin");
             else strcat (oname, ".bin");
 	    ofile = fopen (oname, "wb");
 	    if (ofile == NULL) {

--- a/converters/strrem/Makefile
+++ b/converters/strrem/Makefile
@@ -3,7 +3,7 @@ TOOL=strrem
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/strrem/strrem.c
+++ b/converters/strrem/strrem.c
@@ -44,7 +44,7 @@ if ((argc < 2) || (argv[0] == NULL)) {
 slen = strlen (srem);
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".new");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".new");
             else strcat (oname, ".new");
 	ifile = fopen (argv[i], "r");
 	if (ifile == NULL) {

--- a/converters/strsub/Makefile
+++ b/converters/strsub/Makefile
@@ -3,7 +3,7 @@ TOOL=strsub
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/strsub/strsub.c
+++ b/converters/strsub/strsub.c
@@ -44,7 +44,7 @@ rmvlen = strlen (rmv);
 ins = argv[2];
 for (i = 3; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".new");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".new");
             else strcat (oname, ".new");
 	ifile = fopen (argv[i], "r");
 	if (ifile == NULL) {

--- a/converters/tar2mt/Makefile
+++ b/converters/tar2mt/Makefile
@@ -3,7 +3,7 @@ TOOL=tar2mt
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/tar2mt/tar2mt.c
+++ b/converters/tar2mt/tar2mt.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <errno.h>
 
+int
 main (int argc, char **argv)
 {
 FILE *fIn = NULL, *fOut = NULL;

--- a/converters/tp512cvt/Makefile
+++ b/converters/tp512cvt/Makefile
@@ -3,7 +3,7 @@ TOOL=tp512cvt
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/tp512cvt/tp512cvt.c
+++ b/converters/tp512cvt/tp512cvt.c
@@ -44,7 +44,7 @@ if ((argc < 2) || (argv[0] == NULL)) {
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".tap");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".tap");
         else strcat (oname, ".tap");
 	ifile = fopen (argv[i], "rb");
 	if (ifile == NULL) {

--- a/converters/tpc2mt/Makefile
+++ b/converters/tpc2mt/Makefile
@@ -3,7 +3,7 @@ TOOL=tpc2mt
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/converters/tpc2mt/tpc2mt.c
+++ b/converters/tpc2mt/tpc2mt.c
@@ -46,7 +46,7 @@ if (argc < 2) {
 
 for (i = 1; i < argc; i++) {
 	strcpy (oname, argv[i]);
-        if (ppos = strrchr (oname, '.')) strcpy (ppos, ".tap");
+        if ((ppos = strrchr (oname, '.'))) strcpy (ppos, ".tap");
                 else strcat (oname, ".tap");
 	ifile = fopen (argv[i], "rb");
 	if (ifile == NULL) {

--- a/crossassemblers/Makefile
+++ b/crossassemblers/Makefile
@@ -3,7 +3,7 @@
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 .PHONY: all clean install uninstall
 

--- a/crossassemblers/hpasm/Makefile
+++ b/crossassemblers/hpasm/Makefile
@@ -3,7 +3,7 @@ TOOL=hpasm
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/crossassemblers/hpasm/hpasm.c
+++ b/crossassemblers/hpasm/hpasm.c
@@ -35,6 +35,7 @@ int      rep_count=0;    /* >0 if REP statement in process */
 char     listfilename[256];
 FILE    *listfile;
 /****************************************************/
+void
 start_listing (nam)
 /*
 **  Initialize listing output file
@@ -44,11 +45,12 @@ char *nam;
     char *ppos;
 
     strncpy (listfilename, nam, 250);
-    if (ppos = strrchr (listfilename, '.')) strcpy (ppos, ".lst");
+    if ((ppos = strrchr (listfilename, '.'))) strcpy (ppos, ".lst");
         else strcat (listfilename, ".lst");
     listfile = fopen (listfilename, "w");
 }
 /****************************************************/
+void
 finish_listing () {
 /*
 **  Finish off listing output file
@@ -67,6 +69,7 @@ long     outcount;
 long     outbufsize=27;
 long     outbuf[27];
 /****************************************************/
+void
 start_output (nam)
 /*
 **  Initialize binary output file
@@ -76,13 +79,14 @@ char *nam;
     char *ppos;
 
     strncpy (outfilename, nam, 250);
-    if (ppos = strrchr (outfilename, '.')) strcpy (ppos, ".bin");
+    if ((ppos = strrchr (outfilename, '.'))) strcpy (ppos, ".bin");
         else strcat (outfilename, ".bin");
     outfile = fopen (outfilename, "wb");
     outaddr = 0;
     outcount = 0;
 }
 /****************************************************/
+void
 send_output () {
 /*
 **  Write block to binary output file
@@ -104,23 +108,25 @@ send_output () {
     outcount = 0;
 }
 /****************************************************/
-output_word (addr,word) 
+void
+output_word (addr2,word) 
 /*
 **  Write word to binary output file
 */
-long addr;
+long addr2;
 long word;
 {
-    if (outcount && (outaddr + outcount) != addr) {
+    if (outcount && (outaddr + outcount) != addr2) {
         send_output();
     }
-    if (!outcount) outaddr = addr;
+    if (!outcount) outaddr = addr2;
     outbuf[outcount++] = word;
     if (outcount == outbufsize) {
         send_output();
     }
 }
 /****************************************************/
+void
 finish_output () {
 /*
 **  Finish current output block, write trailing leader,
@@ -133,6 +139,7 @@ finish_output () {
     printf ("Output is in %s\n", outfilename);
 }
 /****************************************************/
+void
 emit (code)
 long code;
 {
@@ -147,6 +154,7 @@ long code;
     addr++;
 }
 /****************************************************/
+void
 err (text)
 char *text;
 {
@@ -221,6 +229,7 @@ long *value;
     *value=0;
 }
 /****************************************************/
+void
 show_labels () 
 {
     long i;
@@ -279,6 +288,7 @@ int double_to_hp (num, a, b)
     return (0);
 }
 /****************************************************/
+void
 parse_digits (base, out) 
 int base;
 long *out;
@@ -293,6 +303,7 @@ long *out;
     *out = val;
 }
 /****************************************************/
+void
 parse_const (out)
 long *out;
 {
@@ -308,6 +319,7 @@ long *out;
     *out = val;
 }
 /****************************************************/
+void
 parse_sym (out)
 long *out;
 {
@@ -335,6 +347,7 @@ long *out;
     }
 }
 /****************************************************/
+void
 parse_term (out)
 long *out;
 {
@@ -349,6 +362,7 @@ long *out;
     }
 }
 /****************************************************/
+void
 parse_neg (out)
 long *out;
 {
@@ -365,6 +379,7 @@ long *out;
     }
 }
 /****************************************************/
+void
 parse_sum (out)
 long *out;
 {
@@ -379,6 +394,7 @@ long *out;
     *out = v1 & 0xFFFF;
 }  
 /****************************************************/
+void
 parse_arg (out)
 long *out;
 {
@@ -387,6 +403,7 @@ long *out;
     parse_sum (out);
 }
 /****************************************************/
+void
 parse_oct (out)
 long *out;
 {
@@ -401,6 +418,7 @@ long *out;
     *out =val;
 }
 /****************************************************/
+void
 parse_dec (out, nbwords)
 long *out, *nbwords;
 {
@@ -428,6 +446,7 @@ long *out, *nbwords;
     }
 }
 /****************************************************/
+void
 mem_group (opcode, code) 
 int opcode;
 long *code;
@@ -449,6 +468,7 @@ long *code;
     code[0] = out;
 }
 /****************************************************/
+void
 io_group (opcode, code)
 int opcode;
 long *code;
@@ -467,6 +487,7 @@ long *code;
     code[0] = out;
 }
 /****************************************************/
+void
 overflow_group (opcode, code)
 int opcode;
 long *code;
@@ -479,6 +500,7 @@ long *code;
     }
 }
 /****************************************************/
+void
 parse_label (label)
 char *label;
 {
@@ -705,6 +727,7 @@ long *code;
     return (ok);
 }
 /****************************************************/
+void
 asm_pass (f)
 FILE *f;
 {
@@ -858,6 +881,7 @@ FILE *f;
     }
 }       
 /****************************************************/
+int
 main (argc,argv)
 int argc;
 char *argv[];
@@ -896,7 +920,7 @@ char *argv[];
             fflush (stdout);
             asm_pass (f1);
             fclose (f1);
-            printf ("%d lines\n", line_count);
+            printf ("%ld lines\n", line_count);
         }
     }
 
@@ -914,7 +938,7 @@ char *argv[];
             printf ("%s ", argv[ii]);
             fflush (stdout);
             asm_pass (f1);
-            printf ("%d lines\n", line_count);
+            printf ("%ld lines\n", line_count);
             fclose (f1);
         }
     }

--- a/crossassemblers/macro1/Makefile
+++ b/crossassemblers/macro1/Makefile
@@ -1,9 +1,9 @@
 # all of these can be over-ridden on the "make" command line if they don't suit your environment.
 TOOL=macro1
-CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow -Wno-missing-field-initializers
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/crossassemblers/macro1/macro1.c
+++ b/crossassemblers/macro1/macro1.c
@@ -150,7 +150,7 @@
 #define NAMELEN             128
 #define SYMBOL_COLUMNS        5
 #define SYMLEN                7
-/*#define SYMSIG	      4		/* EXP: significant chars in a symbol */
+/*#define SYMSIG	      4		*//* EXP: significant chars in a symbol */
 #define SYMBOL_TABLE_SIZE  8192
 #define MAC_MAX_ARGS         20
 #define MAC_MAX_LENGTH     8192
@@ -169,7 +169,7 @@
 #define CONCISE_UC 074
 
 /* Macro to get the number of elements in an array. */
-#define DIM(a) (sizeof(a)/sizeof(a[0]))
+#define DIM(a) ((int)(sizeof(a)/sizeof(a[0])))
 
 #define ISBLANK(c) ((c==' ') || (c=='\f'))
 #define ISEND(c)   ((c=='\0')|| (c=='\n') || (c == '\t'))
@@ -1938,7 +1938,7 @@ void printPageBreak()
 
 /*  Function:  printLine */
 /*  Synopsis:  Output a line to the listing file with new page if necessary. */
-void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
+void printLine( char *outline, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
 {
   if( listfile == NULL )
   {
@@ -1955,7 +1955,7 @@ void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
   default:
   case LINE:
     fprintf( listfile, "%5d                   ", lineno );
-    fputs( line, listfile );
+    fputs( outline, listfile );
     listed = TRUE;
     break;
 
@@ -1963,7 +1963,7 @@ void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
     if( !listed )
     {
       fprintf( listfile, "%5d       %6.6o      ", lineno, val );
-      fputs( line, listfile );
+      fputs( outline, listfile );
       listed = TRUE;
     }
     else
@@ -1976,7 +1976,7 @@ void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
     if( !listed )
     {
       fprintf( listfile, "%5d %5.5o             ", lineno, loc );
-      fputs( line, listfile );
+      fputs( outline, listfile );
       listed = TRUE;
     }
     else
@@ -1989,7 +1989,7 @@ void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
     if( !listed )
     {
       fprintf( listfile, "%5d %5.5o %6.6o      ", lineno, loc, val );
-      fputs( line, listfile );
+      fputs( outline, listfile );
       listed = TRUE;
     }
     else
@@ -2154,8 +2154,8 @@ void punchLocObject( WORD32 loc, WORD32 val )
 {
     if (!rim_mode) {
 	if ((loc & LOADERBUFMASK) == 0 || /* full/force alignment */
-	    loaderbufcount > 0 &&
-	    loc != loaderbufstart + loaderbufcount) /* disjoint */
+	    (loaderbufcount > 0 &&
+	    loc != loaderbufstart + loaderbufcount)) /* disjoint */
 	    flushLoader();
 	if (loaderbufcount == 0)
 	    loaderbufstart = loc;

--- a/crossassemblers/macro11/dumpobj.c
+++ b/crossassemblers/macro11/dumpobj.c
@@ -597,7 +597,7 @@ void got_rld(char *cp, int len)
 
 void got_isd(char *cp, int len)
 {
-	printf("ISD len=%o\n");
+	printf("ISD len=%o\n", len);
 }
 
 void got_endmod(char *cp, int len)

--- a/crossassemblers/macro11/macro11.c
+++ b/crossassemblers/macro11/macro11.c
@@ -717,8 +717,8 @@ static void list_source(STREAM *str, char *cp)
 			binline = memcheck(malloc(sizeof(LSTFORMAT) + 16));
 
 		sprintf(binline, "%*s%*d",
-			SIZEOF_MEMBER(LSTFORMAT, flag), "",
-			SIZEOF_MEMBER(LSTFORMAT, line_number), str->line);
+			(int)SIZEOF_MEMBER(LSTFORMAT, flag), "",
+			(int)SIZEOF_MEMBER(LSTFORMAT, line_number), str->line);
 	}
 }
 
@@ -765,15 +765,15 @@ static void list_fit(STREAM *str, unsigned addr)
 		listline[0] = 0;
 		binline[0] = 0;
 		sprintf(binline, "%*s %6.6o",
-			offsetof(LSTFORMAT, pc), "",
+			(int)offsetof(LSTFORMAT, pc), "",
 			addr);
 		padto(binline, offsetof(LSTFORMAT, words));
 	}
 	else if(strlen(binline) <= col2)
 	{
 		sprintf(binline, "%*s%*d %6.6o",
-			SIZEOF_MEMBER(LSTFORMAT, flag), "",
-			SIZEOF_MEMBER(LSTFORMAT, line_number), str->line,
+			(int)SIZEOF_MEMBER(LSTFORMAT, flag), "",
+			(int)SIZEOF_MEMBER(LSTFORMAT, line_number), str->line,
 			addr);
 		padto(binline, offsetof(LSTFORMAT, words));
 	}
@@ -788,8 +788,8 @@ static void list_value(STREAM *str, unsigned word)
 		/* Print the value and go */
 		binline[0] = 0;
 		sprintf(binline, "%*s%*d %6.6o",
-			SIZEOF_MEMBER(LSTFORMAT, flag), "",
-			SIZEOF_MEMBER(LSTFORMAT, line_number), str->line,
+			(int)SIZEOF_MEMBER(LSTFORMAT, flag), "",
+			(int)SIZEOF_MEMBER(LSTFORMAT, line_number), str->line,
 			word & 0177777);
 	}
 }
@@ -999,7 +999,7 @@ int parse_float(char *cp, char **endp, int size, unsigned *flt)
 		}
 	}
 
-	flt[0] = (unsigned) (sign | (exp << 7) | (ufrac >> 48) & 0x7F);
+	flt[0] = (unsigned) (sign | (exp << 7) | ((ufrac >> 48) & 0x7F));
 	if(size > 1)
 	{
 		flt[1] = (unsigned) ((ufrac >> 32) & 0xffff);
@@ -1220,7 +1220,7 @@ static char *get_symbol(char *cp, char **endp, int *islocal)
 			if(symcp[len-1] == '$')
 			{
 				char *newsym = memcheck(malloc(32));	/* Overkill */
-				sprintf(newsym, "%d$%d", strtol(symcp, NULL, 10), lsb);
+				sprintf(newsym, "%d$%d", (int)strtol(symcp, NULL, 10), lsb);
 				free(symcp);
 				symcp = newsym;
 				if(islocal)
@@ -2519,6 +2519,7 @@ void implicit_gbl(EX_TREE *value)
 	case EX_NEG:
 		implicit_gbl(value->data.child.left);
 		break;
+	case EX_TEMP_SYM:
 	case EX_ERR:
 		if(value->data.child.left)
 			implicit_gbl(value->data.child.left);
@@ -3143,7 +3144,7 @@ MACRO *defmacro(char *cp, STACK *stack, int called)
 	while(!EOL(*cp))
 	{
 		arg = new_arg();
-		if(arg->locsym = (*cp == '?')) /* special argument flag? */
+		if((arg->locsym = (*cp == '?'))) /* special argument flag? */
 			cp++;
 		arg->label = get_symbol(cp, &cp, NULL);
 		if(arg->label == NULL)
@@ -3247,7 +3248,7 @@ BUFFER *subst_args(BUFFER *text, ARG *args)
 			label = get_symbol(in, &next, NULL);
 			if(label)
 			{
-				if(arg = find_arg(args, label))
+				if((arg = find_arg(args, label)))
 				{
 					/* An apostrophy may appear before or after the symbol. */
 					/* In either case, remove it from the expansion. */
@@ -4482,7 +4483,7 @@ reassemble:
 							else
 							{
 								strncpy(macfile, label, sizeof(macfile));
-								strncat(macfile, ".MAC", sizeof(macfile) - strlen(macfile));
+								strncat(macfile, ".MAC", sizeof(macfile) - strlen(macfile) - 1);
 								my_searchenv(macfile, "MCALL", hitfile, sizeof(hitfile));
 								if(hitfile[0])
 									macstr = new_file_stream(hitfile);

--- a/crossassemblers/macro11/rad50.c
+++ b/crossassemblers/macro11/rad50.c
@@ -37,6 +37,7 @@ DAMAGE.
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "rad50.h"
 

--- a/crossassemblers/macro7/Makefile
+++ b/crossassemblers/macro7/Makefile
@@ -1,9 +1,9 @@
 # all of these can be over-ridden on the "make" command line if they don't suit your environment.
 TOOL=macro7
-CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow -Wno-missing-field-initializers
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/crossassemblers/macro7/macro7.c
+++ b/crossassemblers/macro7/macro7.c
@@ -125,7 +125,7 @@
 #define OP_CODE        0740000
 
 /* Macro to get the number of elements in an array.                           */
-#define DIM(a) (sizeof(a)/sizeof(a[0]))
+#define DIM(a) ((int)(sizeof(a)/sizeof(a[0])))
 
 /* Macro to get the address plus one of the end of an array.                  */
 #define BEYOND(a) ((a) + DIM(A))
@@ -1544,7 +1544,7 @@ void readLine()
       if( islower( mc ))        /* Encoded argument number?                   */
       {
         ix = mc - 'a';          /* Convert to index.                          */
-        if( iy = mac_arg_pos[ix] )
+        if(( iy = mac_arg_pos[ix] ))
         {
           do                    /* Copy argument string.                      */
             {
@@ -1667,7 +1667,7 @@ void printPageBreak()
 /*  Synopsis:  Output a line to the listing file with new page if necessary.  */
 /*                                                                            */
 /******************************************************************************/
-void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
+void printLine( char *outline, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
 {
   if( listfile == NULL )
   {
@@ -1684,7 +1684,7 @@ void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
   default:
   case LINE:
     fprintf( listfile, "%5d                   ", lineno );
-    fputs( line, listfile );
+    fputs( outline, listfile );
     listed = TRUE;
     break;
 
@@ -1692,7 +1692,7 @@ void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
     if( !listed )
     {
       fprintf( listfile, "%5d       %6.6o      ", lineno, val );
-      fputs( line, listfile );
+      fputs( outline, listfile );
       listed = TRUE;
     }
     else
@@ -1712,7 +1712,7 @@ void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
       {
         fprintf( listfile, "%5d %5.5o %6.6o      ", lineno, loc, val );
       }
-      fputs( line, listfile );
+      fputs( outline, listfile );
       listed = TRUE;
     }
     else
@@ -1916,6 +1916,7 @@ void punchLiteralPool( LPOOL_T *p, WORD32 lpool_page )
 WORD32 insertLiteral( LPOOL_T *p, WORD32 pool_page, WORD32 value )
 {
   WORD32  ix;
+  (void)pool_page; /* unused */
 
   /* Search the literal pool for any occurence of the needed value.           */
   ix = LIT_BASE - 1;

--- a/crossassemblers/macro8x/Makefile
+++ b/crossassemblers/macro8x/Makefile
@@ -1,9 +1,9 @@
 # all of these can be over-ridden on the "make" command line if they don't suit your environment.
 TOOL=macro8x
-CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
+CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow -Wno-missing-field-initializers
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 $(TOOL): $(TOOL).c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TOOL) $(TOOL).c $(LDLIBS)

--- a/crossassemblers/macro8x/macro8x.c
+++ b/crossassemblers/macro8x/macro8x.c
@@ -194,7 +194,7 @@
 #define GET_PAGE(x)    (((x) >> 7) & (TOTAL_PAGES - 1))
 
 /* Macro to get the number of elements in an array.                           */
-#define DIM(a) (sizeof(a)/sizeof(a[0]))
+#define DIM(a) ((int)(sizeof(a)/sizeof(a[0])))
 
 /* Macro to get the address plus one of the end of an array.                  */
 #define BEYOND(a) ((a) + DIM(A))
@@ -2384,7 +2384,7 @@ void readLine()
       if( islower( mc ))        /* Encoded argument number?                   */
       {
         ix = mc - 'a';          /* Convert to index.                          */
-        if( iy = mac_arg_pos[ix] )
+        if(( iy = (WORD32)mac_arg_pos[ix] ))
         {
           do                    /* Copy argument string.                      */
             {
@@ -2523,7 +2523,7 @@ void printPageBreak()
 /*  Synopsis:  Output a line to the listing file with new page if necessary.  */
 /*                                                                            */
 /******************************************************************************/
-void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
+void printLine( char *outline, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
 {
   if( listfile == NULL )
   {
@@ -2540,7 +2540,7 @@ void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
   default:
   case LINE:
     fprintf( listfile, "%5d             ", lineno );
-    fputs( line, listfile );
+    fputs( outline, listfile );
     listed = TRUE;
     break;
 
@@ -2548,7 +2548,7 @@ void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
     if( !listed )
     {
       fprintf( listfile, "%5d       %4.4o  ", lineno, val );
-      fputs( line, listfile );
+      fputs( outline, listfile );
       listed = TRUE;
     }
     else
@@ -2568,7 +2568,7 @@ void printLine( char *line, WORD32 loc, WORD32 val, LINESTYLE_T linestyle )
       {
         fprintf( listfile, "%5d %5.5o %4.4o  ", lineno, loc, val );
       }
-      fputs( line, listfile );
+      fputs( outline, listfile );
       listed = TRUE;
     }
     else

--- a/extracters/Makefile
+++ b/extracters/Makefile
@@ -3,7 +3,7 @@
 CFLAGS=-O2 -Wall -Wshadow -Wextra -pedantic -Woverflow -Wstrict-overflow
 BIN=/usr/local/bin
 INSTALL=install
-CC=gcc
+#CC=gcc
 
 .PHONY: all clean install uninstall
 

--- a/extracters/mmdir/mmdir.c
+++ b/extracters/mmdir/mmdir.c
@@ -32,7 +32,7 @@
 
 int main (int argc, char *argv[])
 {
-int obj, i, k, fc, rc, tpos, sa, ea, fr, fq;
+int i, k, fc, rc, tpos, sa, ea, fr, fq;
 unsigned char b[53];
 unsigned char bca[4];
 unsigned int bc;
@@ -67,7 +67,7 @@ for (i = 1; i < argc; i++) {
 		    printf ("End of logical tape\n");
 		    break;  }
 		preveof = 1;
-		fc++; obj++;
+		fc++;
 		rc = 1;
 		tpos = tpos + 4;  }
 	    else if (bc > MAXRLNT) {

--- a/extracters/mtdump/mtdump.c
+++ b/extracters/mtdump/mtdump.c
@@ -43,7 +43,7 @@ int main (int argc, char *argv[])
 {
 int obj, i, k, fc, rc, tpos;
 unsigned int bc = 0, fmt, rlntsiz;
- unsigned char *s;
+ char *s;
  unsigned char bca[4] = { 0,0,0,0 };
 int preveof, gapcount, gpos = 0, gincr;
 FILE *ifile;

--- a/extracters/rawcopy/RawCopy.c
+++ b/extracters/rawcopy/RawCopy.c
@@ -40,10 +40,10 @@ while (0 != (bytesread = fread(buf, 1, readsize, fin)))
     else
        totalbytes += bytesread;
     if (0 == (totalbytes%(1024*1024)))
-        fprintf(stderr, "%6dMB Copied...\r", totalbytes/(1024*1024));
+        fprintf(stderr, "%6ldMB Copied...\r", (long)totalbytes/(1024*1024));
     }
 fprintf(stderr, "\n");
-fprintf(stderr, "Total Data: %6.2f MBytes (%d bytes)\n", totalbytes/(1024.0*1024.0), totalbytes);
+fprintf(stderr, "Total Data: %6.2f MBytes (%ld bytes)\n", totalbytes/(1024.0*1024.0), (long)totalbytes);
 fclose(fin);
 fclose(fout);
  exit(0);

--- a/extracters/tpdump/tpdump.c
+++ b/extracters/tpdump/tpdump.c
@@ -174,7 +174,7 @@ int main ( int argc, char* argv[] )
       recsiz2 = read_len ( fi );
       if ( recsiz2 != recsiz )
       { printf("Unequal starting and ending record sizes: %d != %d\n",
-          recsiz, recsiz2);
+          (int)recsiz, (int)recsiz2);
         return(4);
       }
     }


### PR DESCRIPTION
There are a lot of warnings when compiling on FreeBSD 10.1 with clang.  I've fixed all but the obsolete tmpnam function warning.  Some were fixed by adding  -Wno-missing-field-initializers to the Makefiles.  The changeset would be much larger if the code itself was fixed.  I also commented out the CC=gcc in all of the Makefiles as most contemporary host systems have a gcc compatible C compiler or gcc is the default. 
