### PR TITLE
Add missing clean for cosy subdirectory in converters/Makefile

### DIFF
--- a/converters/Makefile
+++ b/converters/Makefile
@@ -32,6 +32,7 @@ all:
 
 clean:
 	cd asc && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
+	cd cosy && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
 	cd dtos8cvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
 	cd hpconvert && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean
 	cd littcvt && $(MAKE) CFLAGS="$(CFLAGS)" BIN="$(BIN)" INSTALL="$(INSTALL)" CC="$(CC)" clean


### PR DESCRIPTION
Running `make clean` didn't clean up the `cosy` binary since this subdirectory was forgotten in the converters Makefile.