### PR TITLE
Fix fsio compilation on FreeBSD

### DIFF
--- a/converters/fsio/fsio.h
+++ b/converters/fsio/fsio.h
@@ -55,13 +55,13 @@ enum openMode           { M_RD, M_WR };
 #define le32toh(x)      OSSwapLittleToHostInt32(x)
 #elif defined(__linux__)
 #include <endian.h>
-#elif defined(__FreeBSD__) || defined(__NetBSD__)
+#elif defined(__NetBSD__)
 #include <sys/endian.h>
 
 #define le16toh(x)      letoh16(x)
 
 #define le32toh(x)      letoh32(x)
-#elif defined(__OpenBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <sys/endian.h>
 #endif
 


### PR DESCRIPTION
Just tried to build fsio on FreeBSD and found it complaining about
unknown functions letoh32.  Turns out that the attempt to make this
portable to FreeBSD is incorrectly assuming that FreeBSD should be
like NetBSD, when in fact it is more like OpenBSD in this regard.

Moving the defined(__FreeBSD__) so it selects the same block as
__OpenBSD__ makes fsio build correctly on FreeBSD 11 (and presumably
later).

I have also checked that the fsio built with this patch actually WORKS.