### PR TITLE
Correct argv test

### DIFF
--- a/converters/tar2mt/tar2mt.c
+++ b/converters/tar2mt/tar2mt.c
@@ -44,7 +44,7 @@ if (argc < 2) {
     fprintf (stderr, "blocksize defaults to 8192\n");
     exit (0);
     }
-if ((argc >= 3) && ((strcmp("-b", argv[1])) || (strcmp("--blocksize", argv[1])))) {
+if ((argc >= 3) && ((strcmp("-b", argv[1]) == 0) || (strcmp("--blocksize", argv[1]) == 0))) {
     if (atoi (argv[2]) <= 0) {
         fprintf (stderr, "Invalid blocksize: %s\n", argv[2]);
         exit (0);


### PR DESCRIPTION
The argv test in tar2mt.c is backwards.  The strcmp tests need to look for "== 0" rather than "!= 0".